### PR TITLE
“As garotas do ENIAC”

### DIFF
--- a/Ada.md
+++ b/Ada.md
@@ -1,0 +1,1 @@
+Augusta Ada King, Condessa de Lovelace, atualmente conhecida como Ada Lovelace, foi uma matemática e escritora inglesa. Hoje é reconhecida principalmente por ter escrito o primeiro algoritmo para ser processado por uma máquina, a máquina analítica de Charles Babbage.


### PR DESCRIPTION
ENIAC girls
Antes de linguagens de programação e sistemas computadorizados para cálculos matemáticos como os que já citamos aqui, entretanto, os primeiros computadores dependiam da influência humana e de aparatos mecânicos para funcionarem, e dependiam bastante dos nossos cérebros. Quando se falava em trajetórias de mísseis e bombas, então, a coisa se tornava ainda mais complicada. Foi aí que entraram as “garotas do ENIAC”, um grupo de seis mulheres que foram as primeiras “computors” da história da informática.

Trabalhando em um dos primeiros supercomputadores criados, na Escola de Engenharia Moore, no estado americano da Pennsylvania, Betty Snyder (a única que não aparece na foto acima), Marlyn Wescoff, Fran Bilas, Kay McNulty, Ruth Lichterman e Adele Goldstine eram responsáveis pela configuração do ENIAC, dando a ele as instruções para realizar os cálculos necessários. Isso significava que elas lidavam, diariamente, com mais de três mil interruptores e botões que ligavam um hardware de 80 toneladas, tudo manualmente.

Mais do que operar o maquinário, elas foram responsáveis por dar o pontapé inicial em muitos protocolos usados até hoje. Goldstine, por exemplo, criou o primeiro manual do ENIAC, com instruções de uso e melhores práticas, enquanto Goldstine e Jennings tiveram influência fundamental em sistemas de “salvamento” de configurações e preferências. Fora do supercomputador, ainda, Snyder criou o primeiro sistema informatizado para o censo americano, inventou o teclado numérico para facilitar na programação e, curiosamente, foi uma das percursoras dos computadores na cor “gelo”, totalmente comuns nos anos de 1990.